### PR TITLE
fix: hide admin settings tabs for members

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -55,6 +55,7 @@ export default function Header() {
     const { t } = useTranslation()
     const { logout } = useAuth()
     const profile = useMainStore((store) => store.profile)
+    const isAdmin = profile?.role === 0
 
     const location = useLocation()
     const isDesktop = useMediaQuery("(min-width: 890px)")
@@ -142,18 +143,20 @@ export default function Header() {
                                                         {t("Profile")}
                                                     </div>
                                                 </DropdownMenuItem>
-                                                <DropdownMenuItem
-                                                    onClick={() => {
-                                                        setDropdownOpen(false)
-                                                        navigate("/dashboard/settings")
-                                                    }}
-                                                    className="cursor-pointer"
-                                                >
-                                                    <div className="flex items-center gap-2 w-full">
-                                                        <Settings />
-                                                        {t("Settings")}
-                                                    </div>
-                                                </DropdownMenuItem>
+                                                {isAdmin && (
+                                                    <DropdownMenuItem
+                                                        onClick={() => {
+                                                            setDropdownOpen(false)
+                                                            navigate("/dashboard/settings")
+                                                        }}
+                                                        className="cursor-pointer"
+                                                    >
+                                                        <div className="flex items-center gap-2 w-full">
+                                                            <Settings />
+                                                            {t("Settings")}
+                                                        </div>
+                                                    </DropdownMenuItem>
+                                                )}
                                             </DropdownMenuGroup>
                                             <DropdownMenuSeparator />
                                             <DropdownMenuItem
@@ -334,18 +337,20 @@ export default function Header() {
                                             {t("Profile")}
                                         </div>
                                     </DropdownMenuItem>
-                                    <DropdownMenuItem
-                                        onClick={() => {
-                                            setDropdownOpen(false)
-                                            navigate("/dashboard/settings")
-                                        }}
-                                        className="cursor-pointer"
-                                    >
-                                        <div className="flex items-center gap-2 w-full">
-                                            <Settings />
-                                            {t("Settings")}
-                                        </div>
-                                    </DropdownMenuItem>
+                                    {isAdmin && (
+                                        <DropdownMenuItem
+                                            onClick={() => {
+                                                setDropdownOpen(false)
+                                                navigate("/dashboard/settings")
+                                            }}
+                                            className="cursor-pointer"
+                                        >
+                                            <div className="flex items-center gap-2 w-full">
+                                                <Settings />
+                                                {t("Settings")}
+                                            </div>
+                                        </DropdownMenuItem>
+                                    )}
                                 </DropdownMenuGroup>
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem onClick={logout} className="cursor-pointer">

--- a/src/components/settings-tab.tsx
+++ b/src/components/settings-tab.tsx
@@ -20,14 +20,14 @@ export const SettingsTab = ({ className }: { className?: string }) => {
                         <TabsTrigger value="/dashboard/settings/user" asChild>
                             <Link to="/dashboard/settings/user">{t("User")}</Link>
                         </TabsTrigger>
+                        <TabsTrigger value="/dashboard/settings/online-user" asChild>
+                            <Link to="/dashboard/settings/online-user">{t("OnlineUser")}</Link>
+                        </TabsTrigger>
+                        <TabsTrigger value="/dashboard/settings/waf" asChild>
+                            <Link to="/dashboard/settings/waf">{t("WAF")}</Link>
+                        </TabsTrigger>
                     </>
                 )}
-                <TabsTrigger value="/dashboard/settings/online-user" asChild>
-                    <Link to="/dashboard/settings/online-user">{t("OnlineUser")}</Link>
-                </TabsTrigger>
-                <TabsTrigger value="/dashboard/settings/waf" asChild>
-                    <Link to="/dashboard/settings/waf">{t("WAF")}</Link>
-                </TabsTrigger>
             </TabsList>
         </Tabs>
     )

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -3,6 +3,7 @@ import { SettingsTab } from "@/components/settings-tab"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Combobox } from "@/components/ui/combobox"
 import {
     Form,
     FormControl,
@@ -21,9 +22,8 @@ import {
     SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { Combobox } from "@/components/ui/combobox"
-import { useNotification } from "@/hooks/useNotfication"
 import { useAuth } from "@/hooks/useAuth"
+import { useNotification } from "@/hooks/useNotfication"
 import useSetting from "@/hooks/useSetting"
 import { asOptionalField } from "@/lib/utils"
 import { nezhaLang, settingCoverageTypes } from "@/types"


### PR DESCRIPTION
## Summary
- Hide the settings dropdown entry for non-admin users.
- Hide admin-only settings tabs so members are not shown links to WAF or online user management routes.

## Verification
- bun run build